### PR TITLE
Added "Ipython" and "Django Extensions" as development dependency also fix console command on makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -32,7 +32,7 @@ compose:
 logs:
 	docker logs $(WHATEVER) --tail 500 --follow
 console:
-	$(ex) /bin/bash
+	$(ex) /bin/sh
 run:
 	$(dj) $(WHATEVER)
 shell:

--- a/Makefile
+++ b/Makefile
@@ -37,6 +37,8 @@ run:
 	$(dj) $(WHATEVER)
 shell:
 	$(dj) shell
+shell_plus:
+	$(dj) shell_plus
 test:
 	$(dj) test --settings=djdict.settings --shuffle --timing --keepdb
 format:

--- a/djdict/settings.py
+++ b/djdict/settings.py
@@ -33,6 +33,9 @@ INSTALLED_APPS = [
     "djcelery_email",
 ]
 
+if DEBUG:
+    INSTALLED_APPS.append('django_extensions')
+
 MIDDLEWARE = [
     "django.middleware.security.SecurityMiddleware",
     "django.contrib.sessions.middleware.SessionMiddleware",

--- a/docker/prod/django/prod.Dockerfile
+++ b/docker/prod/django/prod.Dockerfile
@@ -12,7 +12,7 @@ RUN --mount=type=cache,target=/var/cache/apk \
 RUN --mount=type=cache,target=/root/.cache/uv \
     --mount=type=bind,source=uv.lock,target=uv.lock \
     --mount=type=bind,source=pyproject.toml,target=pyproject.toml \
-    uv sync --frozen
+    uv sync --frozen --no-dev
 
 COPY . .
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -55,3 +55,10 @@ django = ["django"]
 
 [tool.ruff.lint.mccabe]
 max-complexity = 20
+
+[tool.uv]
+dev-dependencies = [
+  "django-extensions==3.2.3",
+  "ipython==8.14.0"
+]
+


### PR DESCRIPTION
This PR:
 - Adds django-extensions and ipython as development dependency.
 - Adds shell_plus command to makefile to add quick access to shell_plus from django extensions.
 - Fixes the console command on makefile which is trying to run /bin/bash which is not existing in the container.